### PR TITLE
Fix held-button-blocking other buttons.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ while (true) {
 
 Triggered when the button is first considered pressed.
 
-Also triggered every 50ms during a long press.
-
 ### BUTTON_UP
 
 Triggered when the button is considered released. In most cases you can use either the UP or DOWN event for your application, and ignore the other.
+
+### BUTTON_HELD
+
+Triggered starting after 2 seconds of long holding a button and then every 50ms thereafter.

--- a/include/button.h
+++ b/include/button.h
@@ -5,9 +5,10 @@
 
 #define BUTTON_DOWN (1)
 #define BUTTON_UP (2)
+#define BUTTON_HELD (3)
 
 typedef struct {
-	uint8_t pin;
+  uint8_t pin;
     uint8_t event;
 } button_event_t;
 

--- a/src/button.c
+++ b/src/button.c
@@ -1,5 +1,3 @@
-// https://github.com/craftmetrics/esp32-button/tree/master/src
-
 #include <stdint.h>
 #include <string.h>
 #include <stdbool.h>


### PR DESCRIPTION
I offer this as an improvement such that holding down one button does not block events on other buttons.  I'm also offering a new BUTTON_HELD event for the repeat so that software using the library can distinguish from the original BUTTON_DOWN event from the events caused by holding the button down.