### PR TITLE
explicit disabled interrupt

### DIFF
--- a/src/button.c
+++ b/src/button.c
@@ -109,6 +109,7 @@ QueueHandle_t pulled_button_init(unsigned long long pin_select, gpio_pull_mode_t
     io_conf.mode = GPIO_MODE_INPUT;
     io_conf.pull_up_en = (pull_mode == GPIO_PULLUP_ONLY || pull_mode == GPIO_PULLUP_PULLDOWN);
     io_conf.pull_down_en = (pull_mode == GPIO_PULLDOWN_ONLY || pull_mode == GPIO_PULLUP_PULLDOWN);;
+    io_conf.intr_type = GPIO_INTR_DISABLE;
     io_conf.pin_bit_mask = pin_select;
     gpio_config(&io_conf);
 


### PR DESCRIPTION
Hi,

I've disabled interrupts explicit.
Because if not, I get
`E (921) gpio: gpio_set_intr_type(144): GPIO interrupt type error
`
because of the uninitialized gpio_config_t struct.

Regards
Dirk