### PR TITLE
Updated for current esp-idf sdk + c++ compilation

### DIFF
--- a/include/button.h
+++ b/include/button.h
@@ -1,5 +1,12 @@
+#ifndef ESP32_BUTTON_H
+#define ESP32_BUTTON_H
+
 #include "freertos/queue.h"
 #include "driver/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define PIN_BIT(x) (1ULL<<x)
 
@@ -14,3 +21,9 @@ typedef struct {
 
 QueueHandle_t button_init(unsigned long long pin_select);
 QueueHandle_t pulled_button_init(unsigned long long pin_select, gpio_pull_mode_t pull_mode);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/button.c
+++ b/src/button.c
@@ -106,6 +106,7 @@ QueueHandle_t pulled_button_init(unsigned long long pin_select, gpio_pull_mode_t
 
     // Configure the pins
     gpio_config_t io_conf;
+    io_conf.intr_type = GPIO_INTR_POSEDGE;
     io_conf.mode = GPIO_MODE_INPUT;
     io_conf.pull_up_en = (pull_mode == GPIO_PULLUP_ONLY || pull_mode == GPIO_PULLUP_PULLDOWN);
     io_conf.pull_down_en = (pull_mode == GPIO_PULLDOWN_ONLY || pull_mode == GPIO_PULLUP_PULLDOWN);;


### PR DESCRIPTION
Hi,

i tried to use this component with a current esp-idf sdk (>=4.3) and since it didn't, i tried to fix it: I've added some wrapper to make this compile with c++ code and added one line to initialize the field io_conf.intr_type with "GPIO_INTR_POSEDGE" (i'm not quite sure if this is the most reasonable value, but it worked for me). If you find these changes useful, i'll be glad to contribute.

kind regards,

Christoph